### PR TITLE
Upgrade elastalert to v0.2.1

### DIFF
--- a/start-elastalert.sh
+++ b/start-elastalert.sh
@@ -30,11 +30,6 @@ else
     echo "Container timezone not modified"
 fi
 
-# Force immediate synchronisation of the time and start the time-synchronization service.
-# In order to be able to use ntpd in the container, it must be run with the SYS_TIME capability.
-# In addition you may want to add the SYS_NICE capability, in order for ntpd to be able to modify its priority.
-ntpd -s
-
 # Elastalert configuration:
 if [ ! -f ${ELASTALERT_CONFIG} ]; then
     cp "${ELASTALERT_HOME}/config.yaml.example" "${ELASTALERT_CONFIG}" && \


### PR DESCRIPTION
This PR upgrade the elastalert version from v0.2.0b to v0.2.1. It also removes all the machinery related to clock syncing since it's no longer an issue with Docker Machine / boot2docker.