### PR TITLE
Fix 0.2.1 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,18 @@ WORKDIR /opt
 
 # Install software required for Elastalert
 RUN apk --update upgrade && \
-    apk add gcc libffi-dev musl-dev python-dev openssl-dev tzdata libmagic
+    apk add gcc libffi-dev musl-dev python-dev openssl-dev tzdata libmagic gettext
+
+# Download Elastalert.
+RUN wget -O elastalert.zip "https://github.com/Yelp/elastalert/archive/${ELASTALERT_VERSION}.zip" && \
+    unzip elastalert.zip && \
+    rm elastalert.zip && \
+    mv elastalert* "${ELASTALERT_HOME}"
 
 WORKDIR "${ELASTALERT_HOME}"
 
 # Install Elastalert.
-RUN pip install elastalert=="${ELASTALERT_VERSION}" && \
+RUN pip install "setuptools>=11.3" && python setup.py install && \
 # Install Supervisor.
     easy_install supervisor && \
 # Create directories. The /var/empty directory is used by openntpd.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ es_password: changeme
 - ELASTICSEARCH_TLS - Use HTTPS when connecting to Elasticsearch (True/False). Default is `False`.
 - ELASTICSEARCH_TLS_VERIFY - Verify server (Elasticsearch) certificate (True/False). Default is `False`.
 - ELASTALERT_INDEX - Name of Elastalert writeback index in Elasticseach. Defaults to `elastalert_status`.
+- ELASTALERT_CONFIG - Path for the elastalert config. If omitted, a config will be generated based on the config template.
+- ELASTALERT_SUPERVISOR_CONF - Path for the supervisord config. If omitted, a config will be generated based on the config template.

--- a/start-elastalert.sh
+++ b/start-elastalert.sh
@@ -60,6 +60,12 @@ if [ ! -f ${ELASTALERT_CONFIG} ]; then
     sed -i -e"s|writeback_index: [[:print:]]*|writeback_index: ${ELASTALERT_INDEX}|g" "${ELASTALERT_CONFIG}"
 fi
 
+# Replace env-vars
+if [ -f ${ELASTALERT_CONFIG} ]; then
+    envsubst < ${ELASTALERT_CONFIG} > ${ELASTALERT_CONFIG}.tmp
+    mv ${ELASTALERT_CONFIG}.tmp ${ELASTALERT_CONFIG}
+fi
+
 # Elastalert Supervisor configuration:
 if [ ! -f ${ELASTALERT_SUPERVISOR_CONF} ]; then
     cp "${ELASTALERT_HOME}/supervisord.conf.example" "${ELASTALERT_SUPERVISOR_CONF}" && \
@@ -70,6 +76,12 @@ if [ ! -f ${ELASTALERT_SUPERVISOR_CONF} ]; then
     sed -i -e"s|stderr_logfile=.*log|stderr_logfile=${LOG_DIR}/elastalert_stderr.log|g" "${ELASTALERT_SUPERVISOR_CONF}"
     # Modify the start-command.
     sed -i -e"s|python elastalert.py|elastalert --config ${ELASTALERT_CONFIG}|g" "${ELASTALERT_SUPERVISOR_CONF}"
+fi
+
+# Replace env-vars
+if [ -f ${ELASTALERT_SUPERVISOR_CONF} ]; then
+    envsubst < ${ELASTALERT_SUPERVISOR_CONF} > ${ELASTALERT_SUPERVISOR_CONF}.tmp
+    mv ${ELASTALERT_SUPERVISOR_CONF}.tmp ${ELASTALERT_SUPERVISOR_CONF}
 fi
 
 # Set authentication if needed


### PR DESCRIPTION
The bootstrap process currently uses the elastalert and supervisord config example files as a base to interpolate the env vars and create the used config files. Thus, by installing elastalert via pip we lose these files.

I've also added a new feature where prior to starting elastalert, replace env var references in the config files.
This allows one to create a env var templated config file and mount that directly in a docker volume instead of having to rely on the elastalert.config.example file as a bootstrap.